### PR TITLE
Revert Pages workflow change — rollback to 729df36

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,8 +1,4 @@
 name: Deploy frontend to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 on:
   push:
@@ -33,10 +29,23 @@ jobs:
         run: |
           cp dist/index.html dist/404.html
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v1
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          path: ./dist
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v1
+      - name: Ensure gh-pages branch exists (force push)
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          cd dist
+          git init
+          git add -A
+          git commit -m "Deploy to gh-pages: $GITHUB_SHA" || echo "no changes to commit"
+          git branch -M gh-pages
+          git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git push -f origin gh-pages


### PR DESCRIPTION
This PR reverts the Pages workflow change (commit 5e3f15a) which caused canceled deployments and restores repository state to behavior matching commit 729df36. A backup branch backup/main-before-reset was created from the pre-rollback origin/main. 