### PR TITLE
ci: adjust cPanel deploy layout and include `.cpanel.yml` artifact

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,25 +1,38 @@
----
-# Конфигурация деплоя cPanel — копирование уже собранных артефактов
-# Предполагается, что CI (GitHub Actions) собирает frontend/dist и backend/dist
-# и пушит их в ветку, которую вы деплоите в cPanel.
-
 deployment:
   tasks:
     - run: "exec > /home/ekaterina/deploy.log 2>&1 || true"
-    - run: "echo '------ DEPLOY START ------' && date"
-    - run: "echo 'Копирование артефактов в public_html и backend...'"
-    - run: "echo 'REPO PATH:' && pwd || true"
-    - run: "echo '--- repo/frontend contents ---' && ls -la /home/ekaterina/repositories/error-logger-viewer/frontend || true"
-    - run: "cd /home/ekaterina/repositories/error-logger-viewer && if [ ! -d frontend/dist ]; then echo 'frontend/dist не найден'; exit 1; fi"
-    - run: "echo '--- repo/frontend/dist contents ---' && ls -la /home/ekaterina/repositories/error-logger-viewer/frontend/dist || true"
-    - run: "cd /home/ekaterina/repositories/error-logger-viewer && if [ -d backend/dist ]; then echo 'backend/dist найден'; else echo 'backend/dist не найден — деплоим только фронтенд'; fi"
-    - run: "echo '--- before public_html ---' && ls -la /home/ekaterina/public_html || true"
-    - run: "rm -rf /home/ekaterina/public_html/* || true"
-    - run: "echo '--- after clean public_html ---' && ls -la /home/ekaterina/public_html || true"
-    - run: "cd /home/ekaterina/repositories/error-logger-viewer && cp -R frontend/dist/* /home/ekaterina/public_html/ || echo 'cp frontend -> public_html exited with code $?'
-    - run: "echo '--- after copy to public_html ---' && ls -la /home/ekaterina/public_html || true"
-    - run: "mkdir -p /home/ekaterina/backend || true"
-    - run: "cd /home/ekaterina/repositories/error-logger-viewer && cp -R backend/dist /home/ekaterina/backend/ || echo 'cp backend exited with code $?'
-    - run: "echo '--- after copy backend ---' && ls -la /home/ekaterina/backend || true"
-    - run: "echo 'Копирование завершено'"
-    - run: "echo '------ DEPLOY END ------' && date"
+    - run: "export DEPLOYPATH=/home/ekaterina/public_html; export BACKENDPATH=/home/ekaterina/backend; echo DEPLOYPATH=$DEPLOYPATH BACKENDPATH=$BACKENDPATH"
+    - run: |
+        echo "------ DEPLOY START ------"
+        date
+        echo "Repo root: $(pwd)"
+        # choose frontend source: frontend/dist (recommended) or frontend (fallback)
+        if [ -d frontend/dist ]; then
+          SRC=frontend/dist
+        elif [ -d frontend ]; then
+          SRC=frontend
+        else
+          echo "No frontend source found (frontend/dist or frontend)"
+          exit 1
+        fi
+        echo "Using frontend source: $SRC"
+        mkdir -p "$DEPLOYPATH"
+        echo "--- before clean $DEPLOYPATH ---"
+        ls -la "$DEPLOYPATH" || true
+        rm -rf "$DEPLOYPATH"/* || true
+        echo "--- copying frontend from $SRC to $DEPLOYPATH ---"
+        cp -a "$SRC"/. "$DEPLOYPATH"/ || echo "cp frontend -> public_html exited with code $?"
+        echo "--- after copy ---"
+        ls -la "$DEPLOYPATH" || true
+        # backend: prefer backend/dist when present
+        if [ -d backend/dist ]; then
+          mkdir -p "$BACKENDPATH"
+          cp -a backend/dist/. "$BACKENDPATH"/ || echo "cp backend/dist exited with code $?"
+        elif [ -d backend ]; then
+          mkdir -p "$BACKENDPATH"
+          cp -a backend/. "$BACKENDPATH"/ || echo "cp backend exited with code $?"
+        else
+          echo "No backend to deploy"
+        fi
+        echo "------ DEPLOY END ------"
+        date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,13 @@ jobs:
           name: dist
           path: frontend/dist
 
+      - name: Upload .cpanel.yml to artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpanel-config
+          path: .cpanel.yml
+
       - name: Push frontend/dist + backend/dist to cpanel-deploy
         if: success()
         env:
@@ -136,9 +143,20 @@ jobs:
         run: |
           set -e
           TMPDIR=$(mktemp -d)
-          cp -R frontend/dist "$TMPDIR/frontend"
+          # copy contents of frontend/dist into TMPDIR/frontend (preserve files, not nested dist/)
+          if [ -d frontend/dist ]; then
+            mkdir -p "$TMPDIR/frontend"
+            cp -a frontend/dist/. "$TMPDIR/frontend/"
+          elif [ -d frontend ]; then
+            mkdir -p "$TMPDIR/frontend"
+            cp -a frontend/. "$TMPDIR/frontend/"
+          fi
           if [ -d backend/dist ]; then
-            cp -R backend/dist "$TMPDIR/backend"
+            mkdir -p "$TMPDIR/backend"
+            cp -a backend/dist/. "$TMPDIR/backend/"
+          elif [ -d backend ]; then
+            mkdir -p "$TMPDIR/backend"
+            cp -a backend/. "$TMPDIR/backend/"
           fi
           # include .cpanel.yml so cpanel-deploy branch contains deployment config
           if [ -f .cpanel.yml ]; then


### PR DESCRIPTION
**Short summary**

Make cPanel deployment robust to CI artifact layout and include `.cpanel.yml` as an artifact for inspection.

**What I changed**

- Updated `.cpanel.yml` to:
    - log to` /home/ekaterina/deploy.log`;
    - detect `dist` or fallback to `frontend`;
    - copy frontend files into `/home/ekaterina/public_html` and backend into `/home/ekaterina/backend` (or repo backend);
    - emit helpful diagnostic output.
- Updated `ci.yml` to:
    - copy artifact contents (use `cp -a .../.`) so `frontend/*` is deployed (no nested `dist/ `folder);
    - upload `.cpanel.yml` as artifact cpanel-config for verification.

**Why**

cPanel was failing to deploy because the file layout pushed by CI did not match paths expected by the deploy script. These changes make the deploy resilient and let us inspect exactly what CI pushes to the `cpanel-deploy` branch.