### PR TITLE
Fix local dev server startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16467,14 +16467,11 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/express/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+      "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/express/node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
       "glob": "^10.5.0"
     },
     "glob": "^10.5.0",
-    "path-to-regexp": "^8.4.2",
+    "router": {
+      "path-to-regexp": "^8.4.2"
+    },
     "rimraf": "^4.0.0"
   }
 }


### PR DESCRIPTION
**Confirmed:** The app did not start cleanly at first, and it was not a missing .env.

The frontend was crashing because package.json globally forced path-to-regexp@8.4.2, which broke webpack-dev-server’s nested Express 4. I scoped that override to Express 5’s router instead, and package-lock.json now lets webpack-dev-server use path-to-regexp@0.1.13.

**After the fix:**
npm run start:all starts successfully.
Frontend responds at http://localhost:8080/ with 200 OK.
Backend responds at http://localhost:3000/errors.
Frontend proxy to /errors also works.
npm test passes: 10 suites, 38 tests.
npm run build:backend passes.

_________

**Bug origin:**
The local dev server startup bug was introduced in f82516a (Harden Docker workflow and clear audit findings, Apr 26, 2026). That commit added a global path-to-regexp@^8.4.2 override in package.json, which forced webpack-dev-server’s nested Express 4 dependency to use path-to-regexp@8.4.2 instead of the compatible 0.1.x version.

**Impact:**
Express 4 expects the older path-to-regexp function API, so npm run start:all failed during frontend startup with:
TypeError: pathRegexp is not a function

**Fix:**
Scoped the override to Express 5’s router dependency only, allowing webpack-dev-server’s Express 4 dependency to resolve path-to-regexp@0.1.13 again.